### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   build-linux:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -62,6 +65,9 @@ jobs:
 
   build-windows:
     runs-on: windows-latest
+    permissions:
+      contents: read
+      actions: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3


### PR DESCRIPTION
Potential fix for [https://github.com/OmgRod/cosmic-cities/security/code-scanning/5](https://github.com/OmgRod/cosmic-cities/security/code-scanning/5)

To fix the issue, the workflow should be updated to include a `permissions` block. This can be added at the root level to apply to all jobs or at the job level to customize permissions for individual jobs. Based on the workflow's actions, the jobs primarily require read access to repository contents (e.g., for checkout) and write access for uploading artifacts. The following permissions can be applied:

- `contents: read` for accessing the repository.
- `actions: write` for uploading artifacts.

The fix should ensure that the permissions are applied at the job level to maintain granularity and avoid granting permissions unnecessarily to jobs that don't require them.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
